### PR TITLE
Update Dockerfile: fix invalid jar error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM openjdk:21-jdk-slim
 
-WORKDIR /src
-
-COPY target/*.jar Balance-Batch-build.jar
+COPY target/Balance-Batch-0.0.2-SNAPSHOT.jar app.jar
 
 EXPOSE 8080
 
 # Set the entrypoint to run the JAR
-ENTRYPOINT ["java", "-jar", "Balance-Batch-build.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
fix AWS ECS failed deployments. remove wildcard path specified at copy command to copy the relevant artifact packaged application jar, rename resulting image and remove workdir command in actions workflow following Github best practices for CI